### PR TITLE
Mirror channel permissions during cloning

### DIFF
--- a/code/client/client.py
+++ b/code/client/client.py
@@ -924,8 +924,17 @@ class ClientListener:
             parent_before = getattr(before, "category_id", None)
             parent_after = getattr(after, "category_id", None)
             parent_changed = parent_before != parent_after
+            perms_before = {
+                t.id: (ow.pair()[0].value, ow.pair()[1].value)
+                for t, ow in before.overwrites.items()
+            }
+            perms_after = {
+                t.id: (ow.pair()[0].value, ow.pair()[1].value)
+                for t, ow in after.overwrites.items()
+            }
+            perms_changed = perms_before != perms_after
 
-            if name_changed or parent_changed:
+            if name_changed or parent_changed or perms_changed:
                 self.schedule_sync()
             else:
                 logger.debug(


### PR DESCRIPTION
## Summary
- include permission overwrites in sitemap and resync when they change
- map role/member overwrites when creating categories or channels
- apply channel and category permissions to mirror the source server

## Testing
- `python -m py_compile code/client/client.py code/client/sitemap.py code/server/server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c56d3de0ec8330816f15a491df4d95